### PR TITLE
Remove the Enum suffix from `ProductTypeEnum`.

### DIFF
--- a/src/CafeNoir.Core/Enumerations.cs
+++ b/src/CafeNoir.Core/Enumerations.cs
@@ -1,6 +1,6 @@
 ﻿namespace CafeNoir.Core;
 
-public enum ProductTypeEnum {
+public enum ProductType {
     Coffee,
     Beverages,
     Food


### PR DESCRIPTION
See https://github.com/teo-tsirpanis/CafeNoir/pull/4#discussion_r828016194 and [this Stack Overflow post](https://stackoverflow.com/questions/920603/is-it-recommended-to-suffix-all-c-sharp-enums-with-enum-to-avoid-naming-confli).